### PR TITLE
validate that the configuration can meet target output production rate

### DIFF
--- a/clock-generator/src/crafting/generate-blueprint.test.ts
+++ b/clock-generator/src/crafting/generate-blueprint.test.ts
@@ -228,4 +228,13 @@ describe("generateClockForConfig", () => {
             });
         });
     });
+    describe("config validation", () => {
+        it("throw error if the current configuration cannot meet the target production rate", async () => {
+            const config = await loadConfigFromFile(ConfigPaths.STONE_BRICKS_DIRECT_INSERT);
+            expect(config.target_output.items_per_second).toBe(120)
+            expect(() => generateClockForConfig(config)).not.toThrowError();
+            config.target_output.items_per_second = 240;
+            expect(() => generateClockForConfig(config)).toThrowError();
+        })
+    })
 });

--- a/clock-generator/src/crafting/generate-blueprint.ts
+++ b/clock-generator/src/crafting/generate-blueprint.ts
@@ -132,6 +132,17 @@ export function generateClockForConfig(
         `No machine with output item ${target_production_rate.machine_production_rate.item} found`
     );
 
+    // validate target production rate can be met
+    const total_output_capacity_per_second = output_machine_state_machines
+        .map(it => it.machine_state.machine.output.production_rate.amount_per_second)
+        .reduce((a, b) => a.add(b), fraction(0))
+        .multiply(fraction(config.target_output.copies));
+    assert(total_output_capacity_per_second.toDecimal() >= target_production_rate.total_production_rate.amount_per_second.toDecimal(),
+       "The current configuration cannot meet the target production rate. " +
+       `Total output capacity is ${total_output_capacity_per_second.toDecimal()} items/second, ` +
+       `but target production rate is ${target_production_rate.total_production_rate.amount_per_second.toDecimal()} items/second.`
+    )
+
     // Find output inserters for each output machine
     const output_inserters = output_machine_state_machines.map(machine_state_machine => {
         const inserter = simulation_context.state_registry


### PR DESCRIPTION

<img width="1263" height="673" alt="image" src="https://github.com/user-attachments/assets/7bfe6b60-da2a-4097-8edd-c3a4a357a393" />

Throws an error if the user creates a configuration that cannot meet the target production rate.

Addresses #4