### PR TITLE
[chore] default to stack size 4 and turbo belts

### DIFF
--- a/clock-generator-ui/src/components/BeltsForm.tsx
+++ b/clock-generator-ui/src/components/BeltsForm.tsx
@@ -12,7 +12,7 @@ import {
     TextField,
     Typography,
 } from '@mui/material';
-import type { BeltFormData, BeltLaneFormData } from '../hooks/useConfigForm';
+import { BELT_FORM_DEFAULT_STACK_SIZE, type BeltFormData, type BeltLaneFormData } from '../hooks/useConfigForm';
 import { FactorioIcon } from './FactorioIcon';
 
 const BELT_TYPES = [
@@ -54,7 +54,7 @@ export function BeltsForm({
         if (belt.lanes.length < 2) {
             const newLanes: [BeltLaneFormData, BeltLaneFormData] = [
                 belt.lanes[0],
-                { ingredient: '', stack_size: 1 },
+                { ingredient: '', stack_size: BELT_FORM_DEFAULT_STACK_SIZE },
             ];
             onUpdate(beltIndex, { lanes: newLanes });
         }
@@ -193,7 +193,7 @@ export function BeltsForm({
                                             beltIndex,
                                             laneIndex,
                                             'stack_size',
-                                            parseInt(e.target.value) || 1
+                                            parseInt(e.target.value) || BELT_FORM_DEFAULT_STACK_SIZE
                                         )
                                     }
                                     inputProps={{ min: 1 }}

--- a/clock-generator-ui/src/hooks/useConfigForm.ts
+++ b/clock-generator-ui/src/hooks/useConfigForm.ts
@@ -51,6 +51,9 @@ export interface BeltFormData {
     lanes: [BeltLaneFormData] | [BeltLaneFormData, BeltLaneFormData];
 }
 
+export const BELT_FORM_DEFAULT_TYPE = 'turbo-transport-belt';
+export const BELT_FORM_DEFAULT_STACK_SIZE = 4;
+
 export interface DrillOverrides {
     enable_control?: EnableControlOverride;
 }
@@ -282,8 +285,8 @@ export function useConfigForm(): UseConfigFormResult {
                     ...prev.belts,
                     {
                         id: maxId + 1,
-                        type: 'transport-belt' as const,
-                        lanes: [{ ingredient: '', stack_size: 1 }] as [BeltLaneFormData],
+                        type: BELT_FORM_DEFAULT_TYPE,
+                        lanes: [{ ingredient: '', stack_size: BELT_FORM_DEFAULT_STACK_SIZE }] as [BeltLaneFormData],
                     },
                 ],
             };


### PR DESCRIPTION
Previously was defaulting to a transport belt and a stack size of 1. 

Let's be real... only megabasers will be using this and we all use turbo belts and max stack size so let's default to that.