### PR TITLE
[fix] fallback to previous recipe for furnaces if defined

### DIFF
--- a/clock-generator-sidecar/info.json
+++ b/clock-generator-sidecar/info.json
@@ -1,10 +1,10 @@
 {
     "name": "clock-generator-sidecar",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "title": "Clock Generator Sidecar",
     "author": "abucnasty",
-    "contact": "",
-    "homepage": "",
+    "contact": "https://github.com/abucnasty/factorio-scripts",
+    "homepage": "https://github.com/abucnasty/factorio-scripts",
     "description": "Select machines to extract crafting speeds and productivity bonuses. Export data for use with the Clock Generator tool.",
     "factorio_version": "2.0",
     "dependencies": [

--- a/clock-generator-sidecar/scripts/extraction.lua
+++ b/clock-generator-sidecar/scripts/extraction.lua
@@ -238,7 +238,7 @@ local function extract_inserter_data(entity)
 
             -- If source is a machine, get its recipe outputs for auto-configuration
             if target_type == "machine" then
-                local recipe, _ = pickup_target.get_recipe()
+                local recipe = helpers.get_recipe_or_previous(pickup_target)
                 if recipe then
                     source_recipe_outputs = {}
                     for _, product in pairs(recipe.products) do
@@ -312,8 +312,8 @@ local function extract_crafting_machine_data(entity)
         return nil
     end
 
-    -- Get recipe (skip entities without active recipe)
-    local recipe, quality = entity.get_recipe()
+    -- Get recipe (fallback to previous_recipe for furnaces that may not have an active recipe)
+    local recipe = helpers.get_recipe_or_previous(entity)
     if not recipe then
         return nil
     end


### PR DESCRIPTION
Furnaces when not active will return `nil` for `LuaEntity:: get_recipe`. This falls back to the `LuaEntity::previous_recipe` in this case.