### PR TITLE
[chore] remove magic buffers in trim function

### DIFF
--- a/clock-generator/src/crafting/generate-blueprint.test.ts
+++ b/clock-generator/src/crafting/generate-blueprint.test.ts
@@ -144,7 +144,7 @@ describe("generateClockForConfig", () => {
             it("has correct tick ranges for output inserter transfers", () => {
                 const inserterTransfers = result.transfer_history.getOrThrow(output_inserter_id);
                 const expected_start_inclusive = 1
-                const expected_end_inclusive = 54
+                const expected_end_inclusive = 49
                 
                 expect(inserterTransfers.length).toBe(1);
                 const transfer = inserterTransfers[0];

--- a/clock-generator/src/crafting/sequence/inventory-transfer-history.ts
+++ b/clock-generator/src/crafting/sequence/inventory-transfer-history.ts
@@ -256,28 +256,7 @@ function computeLastSwingOffsetDuration(
     }
 
     if (mode === SimulationMode.PREVENT_DESYNCS || mode === SimulationMode.LOW_INSERTION_LIMITS) {
-        const inserter_stack_size = inserter.metadata.stack_size;
-        const amount_per_craft_int = Math.ceil(source_machine.output.amount_per_craft.toDecimal());
-        /**
-         * okay... so...
-         * this is going to look like magic because, it is.
-         * Purely by observation, the following buffers are ideal for handling desyncs 
-         * when dealing with low insertion limits.
-         * 
-         * | Recipe | Amount Per Craft | Ideal Buffer |
-         * | ------ | ---------------- | ------------ |
-         * | green  | 2                | 4            |
-         * | blue   | 4                | 2            |
-         * | yellow | 6                | 0            |
-         * | purple | 6                | 0            |
-         * 
-         * These most likely only work with legendary stack inserters at stack size 16 but ¯\_(ツ)_/¯
-         */
-        if (amount_per_craft_int < inserter_stack_size) {
-            const max_buffer = 7
-            const buffer = Math.max(0, max_buffer - amount_per_craft_int)
-            return Duration.ofTicks(buffer)
-        }
+        return Duration.zero
     }
     return Duration.zero;
 }


### PR DESCRIPTION
Due to the fix from #41 to belt drop rates, the magic buffer formulas can be **finally** completely eliminated.

This has been bothering me for a while now and is nice to know the reason for the off by one errors propagating as the number of output swings increased for relatively short recipes.