### PR TITLE
Low Insertion Limit Inputs Enabled after Output Inserter

### DIFF
--- a/clock-generator/resources/config-samples/utility-science-belted-combined-blue-and-lds.json
+++ b/clock-generator/resources/config-samples/utility-science-belted-combined-blue-and-lds.json
@@ -1,0 +1,104 @@
+{
+  "target_output": {
+    "recipe": "utility-science-pack",
+    "items_per_second": 120,
+    "copies": 7
+  },
+  "machines": [
+    {
+      "id": 1,
+      "recipe": "utility-science-pack",
+      "productivity": 100,
+      "crafting_speed": 62.99999952316284,
+      "type": "machine"
+    }
+  ],
+  "inserters": [
+    {
+      "source": {
+        "type": "belt",
+        "id": 1
+      },
+      "sink": {
+        "type": "machine",
+        "id": 1
+      },
+      "stack_size": 16,
+      "filters": [
+        "flying-robot-frame",
+        "flying-robot-frame"
+      ]
+    },
+    {
+      "source": {
+        "type": "machine",
+        "id": 1
+      },
+      "sink": {
+        "type": "belt",
+        "id": 1
+      },
+      "stack_size": 16,
+      "filters": [
+        "utility-science-pack"
+      ]
+    },
+    {
+      "source": {
+        "type": "belt",
+        "id": 3
+      },
+      "sink": {
+        "type": "machine",
+        "id": 1
+      },
+      "stack_size": 16,
+      "filters": [
+        "low-density-structure",
+        "processing-unit"
+      ],
+      "overrides": {}
+    }
+  ],
+  "belts": [
+    {
+      "id": 1,
+      "type": "turbo-transport-belt",
+      "lanes": [
+        {
+          "ingredient": "flying-robot-frame",
+          "stack_size": 4
+        },
+        {
+          "ingredient": "flying-robot-frame",
+          "stack_size": 4
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "turbo-transport-belt",
+      "lanes": [
+        {
+          "ingredient": "utility-science-pack",
+          "stack_size": 4
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "turbo-transport-belt",
+      "lanes": [
+        {
+          "ingredient": "low-density-structure",
+          "stack_size": 4
+        },
+        {
+          "ingredient": "processing-unit",
+          "stack_size": 4
+        }
+      ]
+    }
+  ],
+  "chests": []
+}

--- a/clock-generator/src/config/config-paths.ts
+++ b/clock-generator/src/config/config-paths.ts
@@ -37,4 +37,5 @@ export const ConfigPaths = {
     LOW_DENSITY_STRUCTURE: path.join(CONFIG_SAMPLES_DIR, 'low-density-structure-120-per-second.json'),
     METALLURGIC_SCIENCE_PACK: path.join(CONFIG_SAMPLES_DIR, 'metallurgic-science-pack.json'),
     LITHIUM_PLATES: path.join(CONFIG_SAMPLES_DIR, 'lithium-plates-40-per-second.json'),
+    UTILITY_SCIENCE_BELTED_COMBINED_BLUE_AND_LDS: path.join(CONFIG_SAMPLES_DIR, 'utility-science-belted-combined-blue-and-lds.json'),
 } as const;

--- a/clock-generator/src/control-logic/enable-control.ts
+++ b/clock-generator/src/control-logic/enable-control.ts
@@ -4,18 +4,24 @@ import { Resettable } from "./resettable";
 
 export interface EnableControl {
     isEnabled(): boolean;
+    /**
+     * Used for debugging purposes to identify the control in logs.
+     */
+    toString?(): string;
 }
 
 export const AlwaysEnabledControl: EnableControl = {
     isEnabled(): boolean {
         return true;
-    }
+    },
+    toString: () => "AlwaysEnabledControl"
 };
 
 const NeverEnabledControl: EnableControl = {
     isEnabled(): boolean {
         return false;
-    }
+    },
+    toString: () => "NeverEnabledControl"
 };
 
 export class EnableControlLambda implements EnableControl {

--- a/clock-generator/src/crafting/generate-blueprint.test.ts
+++ b/clock-generator/src/crafting/generate-blueprint.test.ts
@@ -104,7 +104,7 @@ describe("generateClockForConfig", () => {
                 // the output inserter swings 6 times, so the end range can be anywhere between 61 and 71
                 // if 72 or more, the inserter will cause instability due to swinging a 7th time
                 const expected_end_inclusive = OpenRange.from(61, 71);
-                
+
                 expect(inserterTransfers.length).toBe(1);
                 const transfer = inserterTransfers[0];
                 expect(transfer.tick_range.start_inclusive).toBe(expected_start_inclusive);
@@ -145,7 +145,7 @@ describe("generateClockForConfig", () => {
                 const inserterTransfers = result.transfer_history.getOrThrow(output_inserter_id);
                 const expected_start_inclusive = 1
                 const expected_end_inclusive = 49
-                
+
                 expect(inserterTransfers.length).toBe(1);
                 const transfer = inserterTransfers[0];
                 expect(transfer.tick_range.start_inclusive).toBe(expected_start_inclusive);
@@ -156,12 +156,12 @@ describe("generateClockForConfig", () => {
                 const inserter_transfers = result.transfer_history.getOrThrow(input_inserter_id)
                 const sorted_transfers = [...inserter_transfers].sort((a, b) => a.tick_range.start_inclusive - b.tick_range.start_inclusive);
                 const expected_ranges = [
-                    OpenRange.from(51, 62),
-                    OpenRange.from(62, 73),
-                    OpenRange.from(80, 91),
-                    OpenRange.from(91, 102)
+                    OpenRange.from(52, 63),
+                    OpenRange.from(63, 74),
+                    OpenRange.from(81, 92),
+                    OpenRange.from(92, 103)
                 ]
-                
+
                 expect(sorted_transfers.length).toBe(4);
                 sorted_transfers.forEach((transfer, index) => {
                     const expected_range = expected_ranges[index];
@@ -171,7 +171,7 @@ describe("generateClockForConfig", () => {
             });
 
         });
-        
+
     });
 
     describe("CHEMICAL_SCIENCE_ENGINES config (multi-output machine)", async () => {
@@ -239,7 +239,7 @@ describe("generateClockForConfig", () => {
     describe("fractional swings", () => {
         describe("PRODUCTION_SCIENCE_SHARED with fractional swings enabled", async () => {
             const configWithFractionalSwings = await loadConfigFromFile(ConfigPaths.PRODUCTION_SCIENCE_SHARED_JSON);
-            
+
             const result = generateClockForConfig(configWithFractionalSwings);
 
             it("has fractional_swings_enabled set to true", () => {
@@ -259,7 +259,7 @@ describe("generateClockForConfig", () => {
             it("swing distributions sum to correct totals", () => {
                 const distribution = result.crafting_cycle_plan.swing_distribution!;
                 const cycle_multiplier = result.crafting_cycle_plan.cycle_multiplier!;
-                
+
                 for (const [entityId, swingDist] of distribution.entries()) {
                     const sum = swingDist.swings_per_subcycle.reduce((a, b) => a + b, 0);
                     expect(sum).toBe(swingDist.total_swings);
@@ -270,7 +270,7 @@ describe("generateClockForConfig", () => {
             it("output inserter has fractional swing distribution", () => {
                 const distribution = result.crafting_cycle_plan.swing_distribution!;
                 const outputInserterDist = distribution.get("inserter:1");
-                
+
                 expect(outputInserterDist).toBeDefined();
                 // Should have alternating distribution (values differ by at most 1)
                 const swings = outputInserterDist!.swings_per_subcycle;
@@ -283,7 +283,7 @@ describe("generateClockForConfig", () => {
                 const base_duration = result.crafting_cycle_plan.total_duration.ticks;
                 const cycle_multiplier = result.crafting_cycle_plan.cycle_multiplier!;
                 const expected_simulation_duration = base_duration * cycle_multiplier;
-                
+
                 expect(result.simulation_duration.ticks).toBe(expected_simulation_duration);
             });
         });
@@ -309,6 +309,35 @@ describe("generateClockForConfig", () => {
 
             it("does not have cycle_multiplier defined", () => {
                 expect(result.crafting_cycle_plan.cycle_multiplier).toBeUndefined();
+            });
+        });
+
+        describe("Utility Science Belted with Combined Blue and LDS", async () => {
+            const config = await loadConfigFromFile(ConfigPaths.UTILITY_SCIENCE_BELTED_COMBINED_BLUE_AND_LDS);
+            const result = generateClockForConfig(config);
+
+            it("has correct tick ranges for input inserter transfers", () => {
+                // Get the actual EntityId instances from the map keys
+                const keys = Array.from(result.crafting_cycle_plan.entity_transfer_map.keys());
+                // inserter id 3 is the LDS + blue chip inserter in this configuration
+                const input_inserter_id: EntityId = keys.find(k => k.id === EntityId.forInserter(3).id)!;
+                
+                const inserter_transfers = result.transfer_history.getOrThrow(input_inserter_id)
+                const sorted_transfers = [...inserter_transfers].sort((a, b) => a.tick_range.start_inclusive - b.tick_range.start_inclusive);
+                const expected_ranges = [
+                    OpenRange.from(38, 49),
+                    OpenRange.from(49, 60),
+                    OpenRange.from(206, 217),
+                    OpenRange.from(217, 228),
+                    OpenRange.from(245, 256),
+                ]
+
+                expect(sorted_transfers.length).toBe(5);
+                sorted_transfers.forEach((transfer, index) => {
+                    const expected_range = expected_ranges[index];
+                    expect(transfer.tick_range.start_inclusive).toBe(expected_range.start_inclusive);
+                    expect(transfer.tick_range.end_inclusive).toBe(expected_range.end_inclusive);
+                })
             });
         });
     });

--- a/clock-generator/src/crafting/sequence/interceptors/inserter-enable-control-factory.ts
+++ b/clock-generator/src/crafting/sequence/interceptors/inserter-enable-control-factory.ts
@@ -457,7 +457,7 @@ export class EnableControlFactory {
                     this.computeEnableRangesToMachine(inserter_state, sink_state)
                 )
             }
-            return AlwaysEnabledControl
+            return this.enabledAfterOutputInserter(inserter_state, sink_state);
         }
 
         if (mode === SimulationMode.NORMAL) {
@@ -570,6 +570,47 @@ export class EnableControlFactory {
         }
 
         return ranges.length > 0 ? ranges : [this.computeEnableRangeFromMachine(inserter_state, source_state)];
+    }
+
+    /**
+     * Sets the enable range per crafting cycle to be after the output inserter for the sink machine has completed its swings
+     * 
+     * The input inserter is enabled from the end of the output inserter's schedule until the end of the crafting cycle.
+     */
+    private enabledAfterOutputInserter(inserter_state: InserterState, sink_state: MachineState): EnableControl {
+        const base_cycle_duration = this.crafting_cycle_plan.total_duration.ticks;
+
+        // Find output inserters for the sink machine (inserters pulling FROM the sink machine)
+        const output_inserters_for_sink = this.entity_state_registry
+            .getAllStates()
+            .filter(EntityState.isInserter)
+            .filter(i => i.inserter.source.entity_id.id === sink_state.machine.entity_id.id);
+
+        // If no output inserters, enable for the entire cycle
+        if (output_inserters_for_sink.length === 0) {
+            return AlwaysEnabledControl
+        }
+
+        // Get the enable ranges for all output inserters and merge them
+        const output_inserter_enable_ranges = OpenRange.reduceRanges(
+            output_inserters_for_sink.map(output_inserter_state => {
+                return this.computeEnableRangeFromMachine(
+                    output_inserter_state,
+                    sink_state,
+                );
+            })
+        );
+
+        // Create enable ranges that start after each output inserter range ends until end of cycle
+        const enabled_ranges: OpenRange[] = output_inserter_enable_ranges.map(range => {
+            const start_tick = range.end_inclusive - 2;
+            return OpenRange.from(start_tick, base_cycle_duration);
+        });
+
+        const merged_ranges = OpenRange.reduceRanges(enabled_ranges);
+        const sorted_ranges = merged_ranges.sort((a, b) => a.start_inclusive - b.start_inclusive);
+
+        return this.clockedForCycle(sorted_ranges.length > 0 ? sorted_ranges : [OpenRange.from(0, base_cycle_duration)]);
     }
 
     private computeEnableRangesToMachine(


### PR DESCRIPTION
Previously, the input inserter would fallback to be always enabled if ratios were not equal between the two items it would input into the assembly machine.

Now the input inserter will wait at a minimum until after the output inserters is scheduled to finish swinging. This creates a stable clock for the utility science example that has been added to the test suite.