### PR TITLE
Force Rails to be an Item

### DIFF
--- a/clock-generator-ui/public/data-filtered.json
+++ b/clock-generator-ui/public/data-filtered.json
@@ -63778,10 +63778,6 @@
       "type": "item",
       "stack_size": 200
     },
-    "straight-rail": {
-      "name": "straight-rail",
-      "type": "item"
-    },
     "uranium-rounds-magazine": {
       "name": "uranium-rounds-magazine",
       "type": "item",
@@ -63944,6 +63940,11 @@
     },
     "bioflux": {
       "name": "bioflux",
+      "type": "item",
+      "stack_size": 100
+    },
+    "rail": {
+      "name": "rail",
       "type": "item",
       "stack_size": 100
     }

--- a/clock-generator/resources/data-filtered.json
+++ b/clock-generator/resources/data-filtered.json
@@ -63778,10 +63778,6 @@
       "type": "item",
       "stack_size": 200
     },
-    "straight-rail": {
-      "name": "straight-rail",
-      "type": "item"
-    },
     "uranium-rounds-magazine": {
       "name": "uranium-rounds-magazine",
       "type": "item",
@@ -63944,6 +63940,11 @@
     },
     "bioflux": {
       "name": "bioflux",
+      "type": "item",
+      "stack_size": 100
+    },
+    "rail": {
+      "name": "rail",
       "type": "item",
       "stack_size": 100
     }

--- a/clock-generator/resources/filter-raw.js
+++ b/clock-generator/resources/filter-raw.js
@@ -10,7 +10,6 @@ const item_categories = new Set([
     "item",
     "module",
     "tool",
-    "straight-rail",
     "ammo",
     "capsule",
 ])
@@ -42,6 +41,16 @@ function mapRawDataToFilteredFactorioData(rawData) {
             filtered["item"][itemName] = mapAsItem(itemData);
         }
     }
+
+    // synthetic items
+
+    // for some reason rail is not an item in the raw data, it is only a recipe
+    filtered["item"]["rail"] = {
+        name: "rail",
+        type: "item",
+        stack_size: 100,
+    }
+
     return filtered;
 }
 

--- a/clock-generator/src/data/factorio-data-service.ts
+++ b/clock-generator/src/data/factorio-data-service.ts
@@ -108,11 +108,6 @@ export class FactorioDataService {
 
     public static readonly DEFAULT_ENERGY_REQUIRED = 0.5
 
-
-    public static interceptor: Map<string, Item> = new Map([
-        ["rail", { name: "rail", type: "item", stack_size: 100 }],
-    ]);
-
     public static findRecipeOrThrow(recipeName: string): EnrichedRecipe {
         const recipe = this.getData().recipe[recipeName]
 
@@ -151,10 +146,6 @@ export class FactorioDataService {
     }
 
     public static findItemOrThrow(itemName: ItemName): Item {
-        const interceptor = this.interceptor.get(itemName);
-        if(interceptor) {
-            return interceptor
-        }
         const data = this.getData();
         const item = data.item[itemName] 
 


### PR DESCRIPTION
Force rails to be an item by synthetically injecting it

Rails for some reason are not an "item" in the raw data dump from factorio. This causes it to not be selectable on the UI. This is now fixed as shown below:
<img width="1177" height="573" alt="image" src="https://github.com/user-attachments/assets/bbe1b92e-4497-4862-a83b-c0b39830533f" />